### PR TITLE
Change "All" link href in Navbar

### DIFF
--- a/components/core/Navbar/Navbar.tsx
+++ b/components/core/Navbar/Navbar.tsx
@@ -20,7 +20,7 @@ const Navbar: FC<Props> = ({ className }) => {
             </a>
           </Link>
           <nav className="space-x-4 ml-6 hidden lg:block">
-            <Link href="/">
+            <Link href="/search">
               <a className={s.link}>All</a>
             </Link>
             <Link href="/search?q=clothes">


### PR DESCRIPTION
Change Navbar "All" link to point to search (but with no specific query) instead of reloading the page (the ACME logo next to it already does that)